### PR TITLE
Rewrite with transpilers for better performance

### DIFF
--- a/AgeTick.cs
+++ b/AgeTick.cs
@@ -1,0 +1,126 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using Verse;
+
+namespace FasterAging
+{
+    /// <summary>
+    /// Patches Pawn_AgeTracker.AgeTick().
+    /// </summary>
+    public static class AgeTick
+    {
+        //Comments further down
+        public static IEnumerable<CodeInstruction> FasterAgingTranspiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            var codes = instructions.ToList();
+            generator.DeclareLocal(typeof(long));
+            var label1 = generator.DefineLabel();
+            Type[] types1 = { typeof(Pawn_AgeTracker) };
+            Type[] types2 = { typeof(Pawn_AgeTracker), typeof(long) };
+            var GetPawnAgingMultiplierMethod = AccessTools.Method(typeof(FasterAging), nameof(FasterAging.GetPawnAgingMultiplier), types1);
+            var ModifyChronologicalAgeMethod = AccessTools.Method(typeof(FasterAging), nameof(FasterAging.ModifyChronologicalAge), types2);
+            for (int i = 0; i < codes.Count; i++)
+            {
+                if (CodesToChange1(codes, i))
+                {
+                    yield return codes[i];
+                    yield return new CodeInstruction(OpCodes.Call, GetPawnAgingMultiplierMethod);
+                    yield return new CodeInstruction(OpCodes.Stloc_0);
+                    yield return new CodeInstruction(OpCodes.Ldloc_0);
+                    yield return new CodeInstruction(OpCodes.Brfalse_S, label1);
+                    yield return new CodeInstruction(OpCodes.Ldarg_0);
+                    yield return codes[i + 1];
+                    yield return codes[i + 2];
+                    codes[i + 3].opcode = OpCodes.Ldloc_0;
+                    yield return codes[i + 3];
+                    i += 4;
+                }
+                else if (CodesToChange2(codes, i))
+                {
+                    yield return codes[i];
+                    yield return new CodeInstruction(OpCodes.Ldloc_0);
+                    codes[i + 1].opcode = OpCodes.Bge_S;
+                    codes[i + 1].operand = label1;
+                    yield return codes[i + 1];
+                    i += 1;
+                }
+                else if (CodesToChange3(codes, i))
+                {
+                    yield return codes[i];
+                    yield return new CodeInstruction(OpCodes.Ldarg_0) { labels = { label1 } };
+                    yield return new CodeInstruction(OpCodes.Ldloc_0);
+                    yield return new CodeInstruction(OpCodes.Call, ModifyChronologicalAgeMethod);
+                }
+                else
+                {
+                    yield return codes[i];
+                }
+            }
+        }
+
+        public static bool CodesToChange1(List<CodeInstruction> codes, int i)
+        {
+            return i < codes.Count - 3 &&
+                   codes[i].opcode == OpCodes.Ldarg_0 &&
+                   codes[i + 1].opcode == OpCodes.Ldarg_0 &&
+                   codes[i + 2].opcode == OpCodes.Ldfld && codes[i + 2].operand as FieldInfo == AccessTools.Field(typeof(Pawn_AgeTracker), nameof(Pawn_AgeTracker.ageBiologicalTicksInt)) &&
+                   codes[i + 3].opcode == OpCodes.Ldc_I4_1 &&
+                   codes[i + 4].opcode == OpCodes.Conv_I8;
+        }
+
+        public static bool CodesToChange2(List<CodeInstruction> codes, int i)
+        {
+            return i < codes.Count - 1 &&
+                   codes[i].opcode == OpCodes.Rem &&
+                   codes[i + 1].opcode == OpCodes.Brtrue_S;
+        }
+
+        public static bool CodesToChange3(List<CodeInstruction> codes, int i)
+        {
+            return codes[i].opcode == OpCodes.Call && codes[i].operand as MethodInfo == AccessTools.Method(typeof(Pawn_AgeTracker), nameof(Pawn_AgeTracker.BirthdayBiological));
+        }
+    }
+
+    /// <summary>
+    /// Above is the transpiler, below is what the result should look like after transpiling.
+    /// </summary>
+
+    class Pawn_AgeTracker_AgeTick
+    {
+        /// <summary>
+        /// The Age Tick.
+        /// </summary>
+        /// <param name="__instance">The pawn</param>
+        private void AgeTick(Pawn_AgeTracker __instance)
+        {
+            //multiplier, adjusted for settings
+            long multiplier = FasterAging.GetPawnAgingMultiplier(__instance);
+
+            //skip the age tick if the multiplier is 0
+            if (multiplier != 0)
+            {
+                //add an amount of ticks equal to the multiplier to age
+                __instance.ageBiologicalTicksInt += multiplier;
+
+                //this part is vanilla
+                if (Find.TickManager.TicksGame >= __instance.nextLifeStageChangeTick)
+                {
+                    __instance.RecalculateLifeStageIndex();
+                }
+
+                //if the remainder of age/years is smaller than the multiplier a birthday happened
+                if (__instance.ageBiologicalTicksInt % 3600000L < multiplier)
+                {
+                    __instance.BirthdayBiological();
+                }
+            }
+
+            //Chronological age modification. Off by default
+            FasterAging.ModifyChronologicalAge(__instance, multiplier);
+        }
+    }
+}

--- a/CompatPatches.cs
+++ b/CompatPatches.cs
@@ -1,0 +1,71 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using Verse;
+
+namespace FasterAging
+{
+    public static class CompatPatches
+    {
+        /// <summary>
+        /// Rocketman slows down the rate at which animals tick and has its own patch to correct the age difference, assuming vanilla values. This patch here adjusts Rocketman's to also take faster aging into account.
+        /// </summary>
+        public static IEnumerable<CodeInstruction> RocketmanCompatibilityTranspiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            var codes = instructions.ToList();
+            Type[] types = { typeof(Pawn_AgeTracker) };
+            var GetPawnAgingMultiplierMethod = AccessTools.Method(typeof(FasterAging), nameof(FasterAging.GetPawnAgingMultiplier), types);
+            for (int i = 0; i < codes.Count; i++)
+            {
+                if (CodesToChange(codes, i))
+                {
+                    yield return new CodeInstruction(OpCodes.Ldarg_0);
+                    yield return new CodeInstruction(OpCodes.Call, GetPawnAgingMultiplierMethod);
+                    yield return new CodeInstruction(OpCodes.Mul);
+                    yield return codes[i];
+                    i += 1;
+                }
+                else
+                {
+                    yield return codes[i];
+                }
+            }
+        }
+
+        //not actually changing all these, but I believe checking for more values than necessary is good here, to avoid hitting other mods
+        public static bool CodesToChange(List<CodeInstruction> codes, int i)
+        {
+            return i > 4 && i < codes.Count - 1 && 
+                   codes[i - 4].opcode == OpCodes.Call && codes[i - 4].operand as MethodInfo == AccessTools.Method(Type.GetType("Soyuz.ContextualExtensions, Soyuz"), "GetDeltaT") &&
+                   codes[i - 3].opcode == OpCodes.Ldc_I4 &&
+                   codes[i - 2].opcode == OpCodes.Sub &&
+                   codes[i - 1].opcode == OpCodes.Conv_I8 &&
+                   codes[i].opcode == OpCodes.Add &&
+                   codes[i + 1].opcode == OpCodes.Conv_I8;
+        }
+    }
+
+    /// <summary>
+    /// Above is the transpiler, below is what the result should look like after transpiling.
+    /// </summary>
+
+    static class CompatPatch
+    {
+        private static void AgeTick_Patch(Pawn_AgeTracker __instance)
+        {
+            if (__instance.pawn.IsValidWildlifeOrWorldPawn() && __instance.pawn.IsSkippingTicks())
+            {
+                //only the multiplier at the end gets added here.
+                __instance.ageBiologicalTicksInt += (__instance.pawn.GetDeltaT() - 1) * FasterAging.GetPawnAgingMultiplier(__instance);
+            }
+        }
+
+        //placeholders for visualization.
+        private static bool IsValidWildlifeOrWorldPawn(this Pawn pawn) { return pawn.RaceProps.Humanlike; }
+        private static bool IsSkippingTicks(this Pawn pawn) { return pawn.RaceProps.Humanlike; }
+        private static int GetDeltaT(this Thing thing) { return GenTicks.TicksGame; }
+    }
+}

--- a/FasterAging.cs
+++ b/FasterAging.cs
@@ -110,46 +110,46 @@ namespace FasterAging
         /// </summary>
         public override void SettingsChanged()
         {
-            if (pawnSpeedMultBeforeCutoffSetting.Value < 0)
+            /*if (pawnSpeedMultBeforeCutoffSetting.Value < 0)
             {
-                pawnSpeedMultBeforeCutoffSetting.Value = 0; //All settings have checks to prevent negative values. Reverse aging ain't happening.
-            }
+                pawnSpeedMultBeforeCutoffSetting.Value = 0; //All settings have checks to prevent negative values. Reverse aging ain't happening. ---> Reverse aging works now, actually. Mostly. The game won't die.
+            }*/
             pawnSpeedMultBeforeCutoff = pawnSpeedMultBeforeCutoffSetting.Value;
 
 
-            if (pawnSpeedMultAfterCutoffSetting.Value < 0)
+            /*if (pawnSpeedMultAfterCutoffSetting.Value < 0)
             {
                 pawnSpeedMultAfterCutoffSetting.Value = 0;
-            }
+            }*/
             pawnSpeedMultAfterCutoff = pawnSpeedMultAfterCutoffSetting.Value;
 
 
-            if (pawnCutoffAgeSetting.Value < 0)
+            /*if (pawnCutoffAgeSetting.Value < 0)
             {
                 pawnCutoffAgeSetting.Value = 0;
-            }
+            }*/
             pawnCutoffAge = pawnCutoffAgeSetting.Value;
 
 
 
-            if (animalSpeedMultBeforeCutoffSetting.Value < 0)
+            /*if (animalSpeedMultBeforeCutoffSetting.Value < 0)
             {
                 animalSpeedMultBeforeCutoffSetting.Value = 0;
-            }
+            }*/
             animalSpeedMultBeforeCutoff = animalSpeedMultBeforeCutoffSetting.Value;
 
 
-            if (animalSpeedMultAfterCutoffSetting.Value < 0)
+            /*if (animalSpeedMultAfterCutoffSetting.Value < 0)
             {
                 animalSpeedMultAfterCutoffSetting.Value = 0;
-            }
+            }*/
             animalSpeedMultAfterCutoff = animalSpeedMultAfterCutoffSetting.Value;
 
 
-            if (animalCutoffAgeSetting.Value < 0)
+            /*if (animalCutoffAgeSetting.Value < 0)
             {
                 animalCutoffAgeSetting.Value = 0;
-            }
+            }*/
             animalCutoffAge = animalCutoffAgeSetting.Value;
 
 

--- a/FasterAging.cs
+++ b/FasterAging.cs
@@ -9,44 +9,69 @@ using Verse;
 using HarmonyLib;
 using HugsLib;
 using HugsLib.Settings;
-using System.Reflection;
-using System;
 
 namespace FasterAging
 {
     /// <summary>
     /// Loads and prepares HugsLib mod config settings, as well as being loaded into HugsLib system for Harmony patching.
     /// </summary>
+    [EarlyInit]
     public class FasterAging : ModBase
     {
         public override string ModIdentifier => "FasterAging";
 
-        private SettingHandle<int> pawnSpeedMultBeforeCutoffSetting; //HugsLib setting controlling the speed multiplier for humanoid pawns below the cutoff age
-        private SettingHandle<int> pawnSpeedMultAfterCutoffSetting; //HugsLib setting controlling the speed multiplier for humanoid pawns equal to or above the cutoff age
-        private SettingHandle<int> pawnCutoffAgeSetting; //HugsLib setting controlling the cutoff age for age speed for humanoid pawns.
+        //Disabling autopatching to allow conditional compatibility patches.
+        protected override bool HarmonyAutoPatch => false;
 
-        private SettingHandle<int> animalSpeedMultBeforeCutoffSetting; //HugsLib setting controlling the speed multiplier for animals below the cutoff age
-        private SettingHandle<int> animalSpeedMultAfterCutoffSetting; //HugsLib setting controlling the speed multiplier for animals equal to or above the cutoff age
-        private SettingHandle<int> animalCutoffAgeSetting; //HugsLib setting controlling the cutoff age for age speed for animals.
+        //The Harmony ID. This can really be whatever, I just chose the least creative name possible here.
+        Harmony harmony = new Harmony(id: "rimworld.Faster.Aging.main");
+
+        private SettingHandle<long> pawnSpeedMultBeforeCutoffSetting; //HugsLib setting controlling the speed multiplier for humanoid pawns below the cutoff age
+        private SettingHandle<long> pawnSpeedMultAfterCutoffSetting; //HugsLib setting controlling the speed multiplier for humanoid pawns equal to or above the cutoff age
+        private SettingHandle<long> pawnCutoffAgeSetting; //HugsLib setting controlling the cutoff age for age speed for humanoid pawns.
+
+        private SettingHandle<long> animalSpeedMultBeforeCutoffSetting; //HugsLib setting controlling the speed multiplier for animals below the cutoff age
+        private SettingHandle<long> animalSpeedMultAfterCutoffSetting; //HugsLib setting controlling the speed multiplier for animals equal to or above the cutoff age
+        private SettingHandle<long> animalCutoffAgeSetting; //HugsLib setting controlling the cutoff age for age speed for animals.
 
         private SettingHandle<bool> modifyChronologicalAgeSetting; //HugsLib setting controlling whether chronological age is also modified.
 
-        private SettingHandle<bool> useAlternateAgingAlgorithmSetting; //HugsLib setting controls whether the mod uses the alternate aging algorithm.
 
+        public static long pawnSpeedMultBeforeCutoff = 1; //Actual value of the pawn speed multiplier before cutoff setting
+        public static long pawnSpeedMultAfterCutoff = 1; //Actual value of the pawn speed multiplier after cutoff setting
+        public static long pawnCutoffAge = 1000; //Actual value of the pawn cutoff age setting
+        public static long PawnCutoffAgeTicks => (pawnCutoffAge * 3600000) + 1000; //Cutoff age converted to ticks. 1000 ticks are added to this value as a buffer around birthdays to prevent repeatedly calling birthday code when aging is disabled.
 
-        public static int pawnSpeedMultBeforeCutoff = 1; //Actual value of the pawn speed multiplier before cutoff setting
-        public static int pawnSpeedMultAfterCutoff = 1; //Actual value of the pawn speed multiplier after cutoff setting
-        public static int pawnCutoffAge = 1000; //Actual value of the pawn cutoff age setting
-        public static long pawnCutoffAgeTicks => (pawnCutoffAge * 3600000) + 1000; //Cutoff age converted to ticks. 1000 ticks are added to this value as a buffer around birthdays to prevent repeatedly calling birthday code when aging is disabled.
-
-        public static int animalSpeedMultBeforeCutoff = 1; //Actual value of the animal speed multiplier before cutoff setting
-        public static int animalSpeedMultAfterCutoff = 1; //Actual value of the animal speed multiplier after cutoff setting
-        public static int animalCutoffAge = 1000; //Actual value of the animal cutoff age setting
-        public static long animalCutoffAgeTicks => (animalCutoffAge * 3600000) + 1000; //Cutoff age converted to ticks. 1000 ticks are added to this value as a buffer around birthdays to prevent repeatedly calling birthday code when aging is disabled.
+        public static long animalSpeedMultBeforeCutoff = 1; //Actual value of the animal speed multiplier before cutoff setting
+        public static long animalSpeedMultAfterCutoff = 1; //Actual value of the animal speed multiplier after cutoff setting
+        public static long animalCutoffAge = 1000; //Actual value of the animal cutoff age setting
+        public static long AnimalCutoffAgeTicks => (animalCutoffAge * 3600000) + 1000; //Cutoff age converted to ticks. 1000 ticks are added to this value as a buffer around birthdays to prevent repeatedly calling birthday code when aging is disabled.
 
         public static bool modifyChronologicalAge = false; //Whether to also change chronological age, not just biological
 
-        public static bool useAlternateAging = false; //Whether to use the alternate aging algorithm.
+        public override void EarlyInitialize()
+        {
+            //Debug Logging. Enabling this puts a harmony.log.txt file with transpiler outputs on the desktop.
+            //Harmony.DEBUG = true;
+
+            //Harmony patches
+            harmony.Patch(AccessTools.Method(typeof(Verse.Pawn_AgeTracker), nameof(Verse.Pawn_AgeTracker.AgeTick)), prefix: null, postfix: null,
+                transpiler: new HarmonyMethod(typeof(AgeTick), nameof(AgeTick.FasterAgingTranspiler)));
+            harmony.Patch(AccessTools.Method(typeof(Verse.Pawn_AgeTracker), nameof(Verse.Pawn_AgeTracker.AgeTickMothballed)), prefix: null, postfix: null,
+                transpiler: new HarmonyMethod(typeof(WorldPawnAgeTick), nameof(WorldPawnAgeTick.FasterAgingWorldPawnTranspiler)));
+            harmony.Patch(AccessTools.Method(typeof(Verse.Pawn_AgeTracker), nameof(Verse.Pawn_AgeTracker.RecalculateLifeStageIndex)), prefix: null, postfix: null,
+                transpiler: new HarmonyMethod(typeof(RecalculateLifeStageIndex), nameof(RecalculateLifeStageIndex.FasterAgingLifeStageTranspiler)));
+        }
+
+        public override void WorldLoaded()
+        {
+            //Fix for Rocketman compatibility. This needs to be loaded late, and WorldLoaded() happens to be late.
+            if (ModLister.HasActiveModWithName("[NTS] [EXPERIMENTAL] RocketMan"))
+            {
+                harmony.Patch(AccessTools.Method(typeof(Verse.Pawn_AgeTracker), nameof(Verse.Pawn_AgeTracker.AgeTick)), prefix: null, postfix: null,
+                    transpiler: new HarmonyMethod(typeof(CompatPatches), nameof(CompatPatches.RocketmanCompatibilityTranspiler)));
+            }
+        }
 
         /// <summary>
         /// Runs during game startup.
@@ -55,32 +80,28 @@ namespace FasterAging
         public override void DefsLoaded()
         {
             //Setup and get settings values
-            pawnSpeedMultBeforeCutoffSetting = Settings.GetHandle<int>(settingName: "speedMultSetting", title: "settings_pawnSpeedMultBefore_title".Translate(), description: "settings_pawnSpeedMultBefore_description".Translate(), defaultValue: 1); //Using old setting title speedMultSetting for compatability
+            pawnSpeedMultBeforeCutoffSetting = Settings.GetHandle<long>(settingName: "speedMultSetting", title: "settings_pawnSpeedMultBefore_title".Translate(), description: "settings_pawnSpeedMultBefore_description".Translate(), defaultValue: 1); //Using old setting title speedMultSetting for compatibility
             pawnSpeedMultBeforeCutoff = pawnSpeedMultBeforeCutoffSetting.Value;
 
-            pawnSpeedMultAfterCutoffSetting = Settings.GetHandle<int>(settingName: "pawnSpeedMultAfter", title: "settings_pawnSpeedMultAfter_title".Translate(), description: "settings_pawnSpeedMultAfter_description".Translate(), defaultValue: 1);
+            pawnSpeedMultAfterCutoffSetting = Settings.GetHandle<long>(settingName: "pawnSpeedMultAfter", title: "settings_pawnSpeedMultAfter_title".Translate(), description: "settings_pawnSpeedMultAfter_description".Translate(), defaultValue: 1);
             pawnSpeedMultAfterCutoff = pawnSpeedMultAfterCutoffSetting.Value;
 
-            pawnCutoffAgeSetting = Settings.GetHandle<int>(settingName: "pawnCutoffAge", title: "settings_pawnCutoffAge_title".Translate(), description: "settings_pawnCutoffAge_description".Translate(), defaultValue: 1000);
+            pawnCutoffAgeSetting = Settings.GetHandle<long>(settingName: "pawnCutoffAge", title: "settings_pawnCutoffAge_title".Translate(), description: "settings_pawnCutoffAge_description".Translate(), defaultValue: 1000);
             pawnCutoffAge = pawnCutoffAgeSetting.Value;
 
 
-            animalSpeedMultBeforeCutoffSetting = Settings.GetHandle<int>(settingName: "animalSpeedMultBefore", title: "settings_animalSpeedMultBefore_title".Translate(), description: "settings_animalSpeedMultBefore_description".Translate(), defaultValue: 1);
+            animalSpeedMultBeforeCutoffSetting = Settings.GetHandle<long>(settingName: "animalSpeedMultBefore", title: "settings_animalSpeedMultBefore_title".Translate(), description: "settings_animalSpeedMultBefore_description".Translate(), defaultValue: 1);
             animalSpeedMultBeforeCutoff = animalSpeedMultBeforeCutoffSetting.Value;
 
-            animalSpeedMultAfterCutoffSetting = Settings.GetHandle<int>(settingName: "animalSpeedMultAfter", title: "settings_animalSpeedMultAfter_title".Translate(), description: "settings_animalSpeedMultAfter_description".Translate(), defaultValue: 1);
+            animalSpeedMultAfterCutoffSetting = Settings.GetHandle<long>(settingName: "animalSpeedMultAfter", title: "settings_animalSpeedMultAfter_title".Translate(), description: "settings_animalSpeedMultAfter_description".Translate(), defaultValue: 1);
             animalSpeedMultAfterCutoff = animalSpeedMultAfterCutoffSetting.Value;
 
-            animalCutoffAgeSetting = Settings.GetHandle<int>(settingName: "animalCutoffAge", title: "settings_animalCutoffAge_title".Translate(), description: "settings_animalCutoffAge_description".Translate(), defaultValue: 1000);
+            animalCutoffAgeSetting = Settings.GetHandle<long>(settingName: "animalCutoffAge", title: "settings_animalCutoffAge_title".Translate(), description: "settings_animalCutoffAge_description".Translate(), defaultValue: 1000);
             animalCutoffAge = animalCutoffAgeSetting.Value;
 
 
             modifyChronologicalAgeSetting = Settings.GetHandle<bool>(settingName: "modifyChronologicalAge", title: "settings_modifyChronologicalAge_title".Translate(), description: "settings_modifyChronologicalAge_description".Translate(), defaultValue: false);
             modifyChronologicalAge = modifyChronologicalAgeSetting.Value;
-
-
-            useAlternateAgingAlgorithmSetting = Settings.GetHandle<bool>(settingName: "useAlternateAgingAlgorithm", title: "settings_useAlternateAgingAlgorithm_title".Translate(), description: "settings_modifyChronologicalAge_description".Translate(), defaultValue: false);
-            useAlternateAging = useAlternateAgingAlgorithmSetting.Value;
         }
 
         /// <summary>
@@ -134,9 +155,6 @@ namespace FasterAging
 
 
             modifyChronologicalAge = modifyChronologicalAgeSetting.Value;
-
-
-            useAlternateAging = useAlternateAgingAlgorithmSetting.Value;
         }
 
         /// <summary>
@@ -144,183 +162,60 @@ namespace FasterAging
         /// </summary>
         /// <param name="pawn">Pawn to determine the age rate multiplier for</param>
         /// <returns></returns>
-        public static int GetPawnAgingMultiplier(Pawn pawn)
+        public static long GetPawnAgingMultiplier(Pawn_AgeTracker _instance)
         {
-            int multiplier = 0; //How much the settings say the pawn's age speed should be multiplied by.
+            Pawn pawn = _instance.pawn;
 
-
-            if (!pawn.RaceProps.Humanlike)
-            {
-                //It's an animal
-                if (pawn.ageTracker.AgeBiologicalTicks >= animalCutoffAgeTicks)
-                {
-                    //It's after the cutoff age
-                    multiplier = animalSpeedMultAfterCutoff;
-                }
-                else
-                {
-                    //It's before the cutoff age
-                    multiplier = animalSpeedMultBeforeCutoff;
-                }
-            }
-            else
+            if (pawn.RaceProps.Humanlike)
             {
                 //It's a humanlike
-                if (pawn.ageTracker.AgeBiologicalTicks >= pawnCutoffAgeTicks)
+                if (pawn.ageTracker.AgeBiologicalTicks >= PawnCutoffAgeTicks)
                 {
                     //It's after the cutoff age
-                    multiplier = pawnSpeedMultAfterCutoff;
+                    return pawnSpeedMultAfterCutoff;
                 }
                 else
                 {
                     //It's before the cutoff age
-                    multiplier = pawnSpeedMultBeforeCutoff;
+                    return pawnSpeedMultBeforeCutoff;
                 }
-            }
-
-
-            return multiplier;
-        }
-    }
-
-    /// <summary>
-    /// Patches Pawn.Tick().
-    /// </summary>
-    [HarmonyPatch(typeof(Verse.Pawn), "Tick")]
-    public static class FasterAgingPatch
-    {
-        /// <summary>
-        /// Runs on every pawn every tick.
-        /// The pawn (__instance) has its AgeTick method called as required.
-        /// </summary>
-        /// <param name="__instance">Pawn that is having its Tick method called</param>
-        [HarmonyPostfix]
-        public static void MultiTick(Pawn __instance)
-        {
-            //Determine multiplier
-            int multiplier = FasterAging.GetPawnAgingMultiplier(__instance);
-
-
-            //Run extra aging.
-            if (multiplier == 0) //Aging is disabled - Manually revert the age increase from the core game's AgeTick call
-            {
-                __instance.ageTracker.AgeBiologicalTicks += -1;
-                //Note - there is still a potential issue if the age multiplier setting is changed by the player to 0 on a birthday tick, causing that birthday to get re-run.
-                //This is a hilariously impossible edge case, but if I want to improve code safety, this is something to work on.
             }
             else
             {
-                if (!FasterAging.useAlternateAging)
+                //It's an animal
+                if (pawn.ageTracker.AgeBiologicalTicks >= AnimalCutoffAgeTicks)
                 {
-                    //Primary aging algorithm - repeat calls AgeTick until a correct number of calls has been made to match the multiplier.
-                    //This system is more performance intensive, and will trip up any mods that expect AgeTick to be called once per pawn tick.
-                    //However, I judge that it is more likely and more problematic that a mod expects a specific age tick count to occur after
-                    //an AgeTick call, which will get skipped using the alternative method.
-                    //Thus this is the default algorithm.
-                    for (int additionalTick = 0; additionalTick < multiplier - 1; additionalTick++) //AgeTick already runs once naturally - subtract 1 from the multiplier to get how many times it should be called again
-                    {
-                        __instance.ageTracker.AgeTick();
-                    }
-                } else
+                    //It's after the cutoff age
+                    return animalSpeedMultAfterCutoff;
+                }
+                else
                 {
-                    //Alternative aging algorithm - directly increment the pawn's age tick value to the appropriate amount. Similar to vanilla AgeTickMothballed
-                    //This is much less performance hungry, but may cause issues if another mod expects AgeTick to only increment the age value by 1, or if 
-                    //another mod has a trigger set up to check for a specific age tick value after AgeTick is called.
-                    //It's an optional alternate method for these reasons.
-                    int ageYearsBefore = __instance.ageTracker.AgeBiologicalYears; //Save the pawn's age before the increment for birthday calculation
-
-                    __instance.ageTracker.AgeBiologicalTicks += multiplier - 1; //Advances the pawn's age value. It has already been increased by 1 by vanilla code.
-
-                    //Vanilla's AgeTickMothballed includes a check for life stage recalculation here.
-                    //I don't think this is necessary/it has already been solved by my daily check.
-                    //It also includes a Find call that I worry might not work well with a mod, so I didn't include the code.
-
-                    //Birthday check - run BiologicalBirthday once for every full year of age that the pawn has advanced during this algorithm
-                    //Tynan used a much more complicated system of comparing age tick values, but I cannot say why. If this is an issue, though, I should replace this with his system.
-                    for (int year = ageYearsBefore; year < __instance.ageTracker.AgeBiologicalYears; year++)
-                    {
-                        __instance.ageTracker.DebugForceBirthdayBiological(); //This method is public where BirthdayBiological is private. The debug method does nothing but call the proper method fortunately.
-                    }
+                    //It's before the cutoff age
+                    return animalSpeedMultBeforeCutoff;
                 }
             }
+        }
 
-
+        //For the pawn tick
+        public static void ModifyChronologicalAge(Pawn_AgeTracker _instance, long multiplier)
+        {
             //Experimental Chronological age modification
             //I judge this too likely to cause issues and too practically insignificant to include as a default feature.
-            if (FasterAging.modifyChronologicalAge)
+            if (modifyChronologicalAge)
             {
-                __instance.ageTracker.BirthAbsTicks -= multiplier - 1; //Move the character's birthday earlier in time, accelerating how distant it is from the current. If multiplier is 0, actually moves birthday forward 1 tick, keeping it a constant distance from the current tick and thus a constant age.
+                _instance.BirthAbsTicks -= multiplier - 1L; //Move the character's birthday earlier in time, accelerating how distant it is from the current. If multiplier is 0, actually moves birthday forward 1 tick, keeping it a constant distance from the current tick and thus a constant age.
             }
         }
-    }
 
-
-    /// <summary>
-    /// Patches Pawn_AgeTracker.AgeTickMothballed()
-    /// </summary>
-    [HarmonyPatch(typeof(Verse.Pawn_AgeTracker), "AgeTickMothballed")]
-    public static class FasterAgingMothballedPatch
-    {
-        /// <summary>
-        /// This patch modifies the core game's AgeTickMothballed's interval argument, which determines how many ageticks to add every call.
-        /// It multiplies this argument to increase or halt the aging rate of mothballed pawns.
-        /// </summary>
-        /// <param name="interval">Vanilla value that determines how many age ticks to advance the pawn through</param>
-        /// <param name="__instance">Pawn that is having its AgeTickMothballed method called</param>
-        [HarmonyPrefix]
-        public static void MultipliedAgeTick(ref int interval, Pawn_AgeTracker __instance)
+        //For the mothball (worldpawn) tick
+        public static void ModifyChronologicalAge(Pawn_AgeTracker _instance, long multiplier, int interval)
         {
-            //Find the pawn this tracker belongs to
-            Pawn pawn = null;
-            FieldInfo pawnFieldInfo = AccessTools.Field(__instance.GetType(), "pawn");
-            if (pawnFieldInfo != null && pawnFieldInfo.FieldType.Equals(typeof(Verse.Pawn)))
+            //Experimental Chronological age modification
+            //I judge this too likely to cause issues and too practically insignificant to include as a default feature.
+            if (modifyChronologicalAge)
             {
-                pawn = (Verse.Pawn)pawnFieldInfo.GetValue(__instance);
-            }
-
-            if (pawn != null)
-            {
-                //Determine multiplier
-                int multiplier = FasterAging.GetPawnAgingMultiplier(pawn);
-
-
-                //Experimental Chronological age modification
-                //I judge this too likely to cause issues and too practically insignificant to include as a default feature.
-                if (FasterAging.modifyChronologicalAge)
-                {
-                    __instance.BirthAbsTicks -= (multiplier - 1) * interval; //Similar system to how the AgeTick patch works, just on the scale of the base interval rather than single ticks. Moves the pawn's birthday to correctly account for modified age rate.
-                }
-
-
-                //Edit the referenced interval value to take the multiplier into account.
-                //The game will now run AgeTickMothballed() with this edited interval, accelerating or halting aging.
-                interval = multiplier * interval;
+                _instance.BirthAbsTicks -= (multiplier - 1L) * interval; //Move the character's birthday earlier in time, accelerating how distant it is from the current. If multiplier is 0, actually moves birthday forward 1 tick, keeping it a constant distance from the current tick and thus a constant age.
             }
         }
-    }
-
-
-    /// <summary>
-    /// Patches Pawn_AgeTracker.AgeTick()
-    /// This fixes a problem caused by how vanilla RimWorld calculates life stages.
-    /// </summary>
-    [HarmonyPatch(typeof(Verse.Pawn_AgeTracker), "AgeTick")]
-    public static class FasterAgingLifestagePatch
-    {
-        /// <summary>
-        /// Runs after AgeTick(), as often as it is called.
-        /// Performs a daily recalculation of life stage.
-        /// </summary>
-        /// <param name="__instance">Pawn that is having its AgeTick method called</param>
-        [HarmonyPostfix]
-        public static void DailyRecalc(Pawn_AgeTracker __instance)
-        {
-            if (Find.TickManager.TicksGame % 60000 == 0)
-            {
-                //Log.Message("I have performed a daily check");
-                MethodInfo info = AccessTools.Method(__instance.GetType(), "RecalculateLifeStageIndex", null, null);
-                info.Invoke(__instance, null);
-            }
-        }
-    }
+    }  
 }

--- a/FasterAging.csproj
+++ b/FasterAging.csproj
@@ -1,65 +1,54 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{300DA299-C4F8-4967-8119-8F74BF1C9784}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>FasterAging</RootNamespace>
     <AssemblyName>FasterAging</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
-    <TargetFrameworkProfile />
+    <TargetFramework>net472</TargetFramework>
+    <LangVersion>8.0</LangVersion>
+	<PlatformTarget>AnyCPU</PlatformTarget>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+	<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>false</DebugSymbols>
     <DebugType>none</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>..\..\..\Documents\Faster Aging\Builds\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <OutputPath>bin\Debug\</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DebugType>none</DebugType>
+    <OutputPath>..\1.2\Assemblies\</OutputPath>
     <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
+    <WarningLevel>0</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony, Version=2.0.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Lib.Harmony.2.0.4\lib\net472\0Harmony.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\RimWorld\RimWorldWin64_Data\Managed\Assembly-CSharp.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="HugsLib">
-      <HintPath>..\..\..\HugsLib\Assemblies\HugsLib.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Runtime.InteropServices.RuntimeInformation" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
+    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.2.2900" GeneratePathProperty="true" />
+    <PackageReference Include="Lib.Harmony" Version="2.0.2" ExcludeAssets="runtime" />
+    <PackageReference Include="TaskPubliciser" Version="1.0.3" />
+    <PackageReference Include="UnlimitedHugs.Rimworld.HugsLib" Version="8.0.0" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="FasterAging.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="MyCode" BeforeTargets="UpdateReferences">
+    <PropertyGroup>
+      <AssemblyCSharp>$(PkgKrafs_Rimworld_Ref)\ref\net472\Assembly-CSharp.dll</AssemblyCSharp>
+      <PubliciseOutputPath>$(PkgKrafs_Rimworld_Ref)\ref\net472\</PubliciseOutputPath>
+      <AssemblyCSharp_Publicised>$(PubliciseOutputPath)Assembly-CSharp_publicised.dll</AssemblyCSharp_Publicised>
+    </PropertyGroup>
+	<Publicise TargetAssemblyPath="$(AssemblyCSharp)" OutputPath="$(PubliciseOutputPath)" Condition="Exists('$(AssemblyCSharp)')" />
+	<ItemGroup>
+      <Reference Include="$(AssemblyCSharp_Publicised)">
+        <SpecificVersion>false</SpecificVersion>
+        <HintPath>$(AssemblyCSharp_Publicised)</HintPath>
+        <Implicit>true</Implicit>
+        <Private>false</Private>
+      </Reference>
+    </ItemGroup>
+  </Target>
+  <Target Name="UpdateReferences" AfterTargets="ResolveLockFileReferences">
+    <ItemGroup>
+      <Reference Remove="$(PkgKrafs_Rimworld_Ref)\ref\net472\Assembly-CSharp.dll" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/RecalculateLifeStageIndex.cs
+++ b/RecalculateLifeStageIndex.cs
@@ -1,0 +1,92 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Emit;
+using UnityEngine;
+using Verse;
+
+namespace FasterAging
+{
+    /// <summary>
+    /// Patches Pawn_AgeTracker.RecalculateLifeStageIndex()
+    /// </summary>
+    public static class RecalculateLifeStageIndex
+    {
+        public static IEnumerable<CodeInstruction> FasterAgingLifeStageTranspiler(IEnumerable<CodeInstruction> instructions)
+        {
+            var codes = instructions.ToList();
+			Type[] types = { typeof(Pawn_AgeTracker) };
+			var GetPawnAgingMultiplierMethod = AccessTools.Method(typeof(FasterAging), nameof(FasterAging.GetPawnAgingMultiplier), types);
+			for (int i = 0; i < codes.Count; i++)
+            {
+                if (CodesToChange(codes, i))
+                {
+                    yield return codes[i];
+					yield return new CodeInstruction(OpCodes.Ldarg_0);
+					yield return new CodeInstruction(OpCodes.Call, GetPawnAgingMultiplierMethod);
+					yield return new CodeInstruction(OpCodes.Conv_R4);
+                    yield return new CodeInstruction(OpCodes.Div);
+                }
+                else
+                {
+                    yield return codes[i];
+                }
+            }
+        }
+
+        public static bool CodesToChange(List<CodeInstruction> codes, int i)
+        {
+            return codes[i].opcode == OpCodes.Ldc_R4 && (float)codes[i].operand == 3600000f;
+        }
+    }
+
+	/// <summary>
+	/// Above is the transpiler, below is what the result should look like after transpiling.
+	/// </summary>
+    class Pawn_AgeTracker_RecalculateLifeStageIndex
+    {
+		/// <summary>
+		/// Method for life stage recalculation
+		/// </summary>
+		/// <param name="__instance">pawn</param>
+		private void RecalculateLifeStageIndex(Pawn_AgeTracker __instance)
+		{
+			int num = -1;
+			List<LifeStageAge> lifeStageAges = __instance.pawn.RaceProps.lifeStageAges;
+			for (int i = lifeStageAges.Count - 1; i >= 0; i--)
+			{
+				if (lifeStageAges[i].minAge <= __instance.AgeBiologicalYearsFloat + 1E-06f)
+				{
+					num = i;
+					break;
+				}
+			}
+			if (num == -1)
+			{
+				num = 0;
+			}
+			bool flag = __instance.cachedLifeStageIndex != num;
+			__instance.cachedLifeStageIndex = num;
+			if (flag && !__instance.pawn.RaceProps.Humanlike)
+			{
+				LongEventHandler.ExecuteWhenFinished(delegate
+				{
+					__instance.pawn.Drawer.renderer.graphics.SetAllGraphicsDirty();
+				});
+				__instance.CheckChangePawnKindName();
+			}
+			if (__instance.cachedLifeStageIndex < lifeStageAges.Count - 1)
+			{
+				float num2 = lifeStageAges[__instance.cachedLifeStageIndex + 1].minAge - __instance.AgeBiologicalYearsFloat;
+				int num3 = (Current.ProgramState == ProgramState.Playing) ? Find.TickManager.TicksGame : 0;
+
+				//Everything except for the multiplier here is vanilla. The multiplier reduces the time to the next lifestagechangetick to match up with the faster aging speed.
+				__instance.nextLifeStageChangeTick = (long)num3 + (long)Mathf.Ceil(num2 * (3600000f / FasterAging.GetPawnAgingMultiplier(__instance)));
+				//as far as I can tell rimworld refreshes this value when reloading a save (as well as when it actually changes)
+				return;
+			}
+			__instance.nextLifeStageChangeTick = long.MaxValue;
+		}
+	}
+}

--- a/WorldPawnAgeTick.cs
+++ b/WorldPawnAgeTick.cs
@@ -1,0 +1,198 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using Verse;
+
+namespace FasterAging
+{
+    /// <summary>
+    /// Patches Pawn_AgeTracker.AgeTickMothballed()
+    /// </summary>
+    public static class WorldPawnAgeTick
+    {
+        //Comments further down
+        public static IEnumerable<CodeInstruction> FasterAgingWorldPawnTranspiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            var codes = instructions.ToList();
+            var label1 = generator.DefineLabel();
+            var label2 = generator.DefineLabel();
+            Type[] types1 = { typeof(Pawn_AgeTracker) };
+            Type[] types2 = { typeof(Pawn_AgeTracker), typeof(long), typeof(int) };
+            var GetPawnAgingMultiplierMethod = AccessTools.Method(typeof(FasterAging), nameof(FasterAging.GetPawnAgingMultiplier), types1);
+            var ModifyChronologicalAgeMethod = AccessTools.Method(typeof(FasterAging), nameof(FasterAging.ModifyChronologicalAge), types2);
+            var BirthAbsTicksProperty = AccessTools.Property(typeof(Pawn_AgeTracker), nameof(Pawn_AgeTracker.BirthAbsTicks));
+            var AgeBiologicalYearsProperty = AccessTools.Property(typeof(Pawn_AgeTracker), nameof(Pawn_AgeTracker.AgeBiologicalYears));
+            var RecalculateLifeStageIndexMethod = AccessTools.Method(typeof(Pawn_AgeTracker), nameof(Pawn_AgeTracker.RecalculateLifeStageIndex));
+            var instruction1 = new CodeInstruction(OpCodes.Blt_S, label2);
+            var instruction2 = new CodeInstruction(OpCodes.Ldarg_0);
+            var instruction3 = new CodeInstruction(OpCodes.Call, RecalculateLifeStageIndexMethod);
+            for (int i = 0; i < codes.Count; i++)
+            {
+                if (CodesToChange1(codes, i))
+                {
+                    yield return codes[i];
+                    yield return new CodeInstruction(OpCodes.Call, GetPawnAgingMultiplierMethod);
+                    yield return codes[i + 2];
+                    yield return new CodeInstruction(OpCodes.Ldloc_0);
+                    yield return new CodeInstruction(OpCodes.Brfalse_S, label1);
+                    yield return new CodeInstruction(OpCodes.Ldarg_0);
+                    yield return codes[i + 1];
+                    i += 2;
+                }
+                else if (CodesToChange2(codes, i))
+                {
+                    yield return codes[i];
+                    yield return codes[i + 1];
+                    yield return codes[i + 2];
+                    yield return new CodeInstruction(OpCodes.Ldloc_0);
+                    yield return new CodeInstruction(OpCodes.Mul);
+                    i += 2;
+                }
+                else if (CodesToChange3(codes, i))
+                {
+                    instruction1 = codes[i];
+                    instruction2 = codes[i + 1];
+                    instruction3 = codes[i + 2];
+                    i += 2;
+                }
+                else if (CodesToChange4(codes, i))
+                {
+                    instruction1.opcode = OpCodes.Blt_S;
+                    instruction1.operand = label2;
+                    yield return instruction1;
+                    yield return instruction2;
+                    yield return instruction3;
+                    codes[i + 2].labels.Add(label2);
+                    i += 1;
+                }
+                else if (CodesToChange5(codes, i))
+                {
+                    codes[i].opcode = OpCodes.Ldc_I4_1;
+                    codes[i].operand = null;
+                    yield return codes[i];
+                }
+                else if (CodesToChange6(codes, i))
+                {
+                    yield return codes[i + 1];
+                    codes[i + 2].opcode = OpCodes.Callvirt;
+                    codes[i + 2].operand = AgeBiologicalYearsProperty.GetGetMethod();
+                    yield return codes[i + 2];
+                    yield return codes[i + 6];
+                    codes[i].opcode = OpCodes.Ldarg_0;
+                    codes[i].labels.Add(label1);
+                    yield return codes[i];
+                    codes[i + 3].opcode = OpCodes.Ldloc_0;
+                    codes[i + 3].operand = null;
+                    yield return codes[i + 3];
+                    codes[i + 4].opcode = OpCodes.Ldarg_1;
+                    yield return codes[i + 4];
+                    codes[i + 5].opcode = OpCodes.Call;
+                    codes[i + 5].operand = ModifyChronologicalAgeMethod;
+                    yield return codes[i + 5];
+                    i += 6;
+                }
+                else
+                {
+                    yield return codes[i];
+                }
+            }
+        }
+
+        public static bool CodesToChange1(List<CodeInstruction> codes, int i)
+        {
+            return i < codes.Count - 2 &&
+                   codes[i].opcode == OpCodes.Ldarg_0 &&
+                   codes[i + 1].opcode == OpCodes.Ldfld &&
+                   codes[i + 2].opcode == OpCodes.Stloc_0;
+        }
+
+        public static bool CodesToChange2(List<CodeInstruction> codes, int i)
+        {
+            return i < codes.Count - 1 &&
+                   codes[i].opcode == OpCodes.Ldfld &&
+                   codes[i + 1].opcode == OpCodes.Ldarg_1 &&
+                   codes[i + 2].opcode == OpCodes.Conv_I8;
+        }
+
+        public static bool CodesToChange3(List<CodeInstruction> codes, int i)
+        {
+            return i < codes.Count - 2 &&
+                   codes[i].opcode == OpCodes.Br_S &&
+                   codes[i + 1].opcode == OpCodes.Ldarg_0 &&
+                   codes[i + 2].opcode == OpCodes.Call && codes[i + 2].operand as MethodInfo == AccessTools.Method(typeof(Pawn_AgeTracker), nameof(Pawn_AgeTracker.RecalculateLifeStageIndex));
+        }
+
+        public static bool CodesToChange4(List<CodeInstruction> codes, int i)
+        {
+            return i < codes.Count - 1 &&
+                   codes[i].opcode == OpCodes.Bge_S &&
+                   codes[i + 1].opcode == OpCodes.Ldloc_0;
+        }
+
+        public static bool CodesToChange5(List<CodeInstruction> codes, int i)
+        {
+            return i < codes.Count - 1 &&
+                   codes[i].opcode == OpCodes.Ldc_I4 &&
+                   codes[i + 1].opcode == OpCodes.Add;
+        }
+
+        public static bool CodesToChange6(List<CodeInstruction> codes, int i)
+        {
+            return i < codes.Count - 5 &&
+                   codes[i].opcode == OpCodes.Conv_I8 &&
+                   codes[i + 1].opcode == OpCodes.Ldarg_0 &&
+                   codes[i + 2].opcode == OpCodes.Ldfld &&
+                   codes[i + 3].opcode == OpCodes.Ldc_I4 &&
+                   codes[i + 4].opcode == OpCodes.Conv_I8 &&
+                   codes[i + 5].opcode == OpCodes.Div &&
+                   codes[i + 6].opcode == OpCodes.Blt_S;
+        }
+    }
+
+    /// <summary>
+    /// Above is the transpiler, below is what the result should look like after transpiling.
+    /// </summary>
+
+    class Pawn_AgeTracker_AgeTickMothballed
+    {
+        /// <summary>
+        /// The world pawn age tick. This triggers once every 15000 regular ticks.
+        /// </summary>
+        /// <param name="__instance">The pawn</param>
+        /// <param name="interval">The interval. 15000.</param>
+        private void AgeTickMothballed(Pawn_AgeTracker __instance, int interval)
+        {
+            //multiplier, adjusted for settings
+            long multiplier = FasterAging.GetPawnAgingMultiplier(__instance);
+
+            //skip the age tick if the multiplier is 0
+            if (multiplier != 0)
+            {
+                //Save a snapshot of the age before ticking
+                long ageBiologicalTicksInt = __instance.ageBiologicalTicksInt;
+
+                //add an amount of ticks equal to the multiplier to age
+                __instance.ageBiologicalTicksInt += interval * multiplier;
+
+                //vanilla code for life stage recalculation
+                //Technically possible for this to work incorrectly with extremely high multipliers combined with animals that only have few lifestages. 
+                if (Find.TickManager.TicksGame >= __instance.nextLifeStageChangeTick)
+                {
+                    __instance.RecalculateLifeStageIndex();
+                }
+
+                //Current age compared to the age in the snapshot above. Birthdays get triggered for every year that passed, though to actually get more than one a multiplier above 240 would be necessary.
+                for (int i = (int)(ageBiologicalTicksInt / 3600000L); i < __instance.AgeBiologicalYears; i++)
+                {
+                    __instance.BirthdayBiological();
+                }
+            }
+
+            //Chronological age modification. Off by default
+            FasterAging.ModifyChronologicalAge(__instance, multiplier, interval);
+        }
+    }
+}

--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Lib.Harmony" version="2.0.4" targetFramework="net472" />
-</packages>


### PR DESCRIPTION
Changes:
- Complete rewrite with transpilers. This should reduce the performance cost by a fairly large amount. Unlike the previous alternate aging algorithm, it works with alien races too.
- Reverse aging is enabled and functional. Pawns won't actually go down lifestages or even die from negative ages with my implementation, but it works. One error is thrown by the UI when trying to display negative ages and that's it.
- All other features are still there too.